### PR TITLE
Task 1.5 Implement Redactor

### DIFF
--- a/phi-detector/src/main.rs
+++ b/phi-detector/src/main.rs
@@ -34,6 +34,7 @@ struct Cli {
 mod file_source;
 mod phi_patterns;
 mod scanner;
+mod redactor;
 
 fn main() {
     let cli = Cli::parse();

--- a/phi-detector/src/redactor.rs
+++ b/phi-detector/src/redactor.rs
@@ -25,9 +25,17 @@ impl Redactor {
 
         for det in sorted {
             if det.start >= last {
+                // Non-overlapping span – redact normally
                 redacted.push_str(&text[last..det.start]);
-                let replacement = self.redaction_text(&det.phi_type, &det.matched_text);
-                redacted.push_str(&replacement);
+                redacted.push_str(&self.redaction_text(&det.phi_type, &det.matched_text));
+                last = det.end;
+            } else if det.end > last {
+                // Overlaps but extends further – make sure the tail gets redacted
+                redacted.push_str(&self.redaction_text(
+                    &det.phi_type,
+                    // use the uncovered slice for length parity
+                    &det.matched_text[(det.matched_text.len() - (det.end - last))..]
+                ));
                 last = det.end;
             }
             // Skip if this detection overlaps with an already processed one

--- a/phi-detector/src/redactor.rs
+++ b/phi-detector/src/redactor.rs
@@ -40,11 +40,11 @@ impl Redactor {
         match self.strategy {
             RedactionStrategy::FullReplacement => match phi_type {
                 PHIType::SSN => "XXX-XX-XXXX".to_string(),
-                PHIType::MedicalRecordNumber => "[REDACTED-MRN]".to_string(),
-                PHIType::ICD10 => "[REDACTED-ICD10]".to_string(),
-                PHIType::DateOfBirth => "[REDACTED-DOB]".to_string(),
-                PHIType::IndonesianNIK => "[REDACTED-NIK]".to_string(),
-                PHIType::IndonesianBPJS => "[REDACTED-BPJS]".to_string(),
+                PHIType::MedicalRecordNumber => "XXXXXXXXXXXX".to_string(),
+                PHIType::ICD10 => "XXX.XXXX".to_string(),
+                PHIType::DateOfBirth => "XX/XX/XXXX".to_string(),
+                PHIType::IndonesianNIK => "XXXXXXXXXXXXXXXX".to_string(),
+                PHIType::IndonesianBPJS => "XXXXXXXXXXXXX".to_string(),
             },
             RedactionStrategy::PartialMasking => match phi_type {
                 PHIType::SSN => {
@@ -145,7 +145,7 @@ mod tests {
         let detections = scanner.scan(text);
         let redactor = Redactor::new(RedactionStrategy::FullReplacement);
         let result = redactor.redact(text, &detections);
-        assert_eq!(result, "SSN: XXX-XX-XXXX, MRN: [REDACTED-MRN]");
+        assert_eq!(result, "SSN: XXX-XX-XXXX, MRN: XXXXXXXXXXXX");
     }
 
     #[test]
@@ -175,7 +175,7 @@ mod tests {
         let detections = scanner.scan(text);
         let redactor = Redactor::new(RedactionStrategy::FullReplacement);
         let result = redactor.redact(text, &detections);
-        assert_eq!(result, "NIK: [REDACTED-NIK], BPJS: [REDACTED-BPJS]");
+        assert_eq!(result, "NIK: XXXXXXXXXXXXXXXX, BPJS: XXXXXXXXXXXXX");
     }
 
     #[test]

--- a/phi-detector/src/redactor.rs
+++ b/phi-detector/src/redactor.rs
@@ -41,8 +41,8 @@ impl Redactor {
         match self.strategy {
             RedactionStrategy::FullReplacement => match phi_type {
                 PHIType::SSN => "XXX-XX-XXXX".to_string(),
-                PHIType::MedicalRecordNumber => "XXXXXXXXXXXX".to_string(),
-                PHIType::ICD10 => "XXX.XXXX".to_string(),
+                PHIType::MedicalRecordNumber => "X".repeat(matched.len()),
+                PHIType::ICD10 => "X".repeat(matched.len()),
                 PHIType::DateOfBirth => "XX/XX/XXXX".to_string(),
                 PHIType::IndonesianNIK => "XXXXXXXXXXXXXXXX".to_string(),
                 PHIType::IndonesianBPJS => "XXXXXXXXXXXXX".to_string(),

--- a/phi-detector/src/redactor.rs
+++ b/phi-detector/src/redactor.rs
@@ -1,0 +1,121 @@
+use crate::scanner::Detection;
+use crate::phi_patterns::PHIType;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RedactionStrategy {
+    FullReplacement,         // e.g., XXX-XX-XXXX
+    PartialMasking,         // e.g., ***-**-1234
+    PlaceholderSubstitution // e.g., [REDACTED-SSN]
+}
+
+pub struct Redactor {
+    pub strategy: RedactionStrategy,
+}
+
+impl Redactor {
+    pub fn new(strategy: RedactionStrategy) -> Self {
+        Self { strategy }
+    }
+
+    pub fn redact(&self, text: &str, detections: &[Detection]) -> String {
+        let mut redacted = String::with_capacity(text.len());
+        let mut last = 0;
+        let mut sorted = detections.to_vec();
+        sorted.sort_by_key(|d| d.start);
+
+        for det in sorted {
+            if det.start >= last {
+                redacted.push_str(&text[last..det.start]);
+                let replacement = self.redaction_text(&det.phi_type, &det.matched_text);
+                redacted.push_str(&replacement);
+                last = det.end;
+            }
+            // If overlaps, skip (already handled by previous match)
+        }
+        redacted.push_str(&text[last..]);
+        redacted
+    }
+
+    fn redaction_text(&self, phi_type: &PHIType, matched: &str) -> String {
+        match self.strategy {
+            RedactionStrategy::FullReplacement => match phi_type {
+                PHIType::SSN => "XXX-XX-XXXX".to_string(),
+                PHIType::MedicalRecordNumber => "[REDACTED-MRN]".to_string(),
+                PHIType::ICD10 => "[REDACTED-ICD10]".to_string(),
+                PHIType::DateOfBirth => "[REDACTED-DOB]".to_string(),
+                PHIType::IndonesianNIK => "[REDACTED-NIK]".to_string(),
+                PHIType::IndonesianBPJS => "[REDACTED-BPJS]".to_string(),
+            },
+            RedactionStrategy::PartialMasking => match phi_type {
+                PHIType::SSN => format!("***-**-{}", &matched[7..]),
+                PHIType::MedicalRecordNumber => {
+                    let len = matched.len();
+                    if len > 4 {
+                        format!("{}{}", "*".repeat(len-4), &matched[len-4..])
+                    } else {
+                        "*".repeat(len)
+                    }
+                },
+                PHIType::ICD10 => "[REDACTED-ICD10]".to_string(),
+                PHIType::DateOfBirth => "[REDACTED-DOB]".to_string(),
+                PHIType::IndonesianNIK => format!("********{}", &matched[8..]),
+                PHIType::IndonesianBPJS => format!("*******{}", &matched[7..]),
+            },
+            RedactionStrategy::PlaceholderSubstitution => match phi_type {
+                PHIType::SSN => "[REDACTED-SSN]".to_string(),
+                PHIType::MedicalRecordNumber => "[REDACTED-MRN]".to_string(),
+                PHIType::ICD10 => "[REDACTED-ICD10]".to_string(),
+                PHIType::DateOfBirth => "[REDACTED-DOB]".to_string(),
+                PHIType::IndonesianNIK => "[REDACTED-NIK]".to_string(),
+                PHIType::IndonesianBPJS => "[REDACTED-BPJS]".to_string(),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::scanner::Scanner;
+    use crate::phi_patterns::PHIPattern;
+
+    #[test]
+    fn test_full_replacement() {
+        let text = "SSN: 123-45-6789, MRN: 12345678";
+        let scanner = Scanner::new(PHIPattern::all_patterns(), 0);
+        let detections = scanner.scan(text);
+        let redactor = Redactor::new(RedactionStrategy::FullReplacement);
+        let result = redactor.redact(text, &detections);
+        assert_eq!(result, "SSN: XXX-XX-XXXX, MRN: [REDACTED-MRN]");
+    }
+
+    #[test]
+    fn test_partial_masking() {
+        let text = "SSN: 123-45-6789, MRN: 12345678";
+        let scanner = Scanner::new(PHIPattern::all_patterns(), 0);
+        let detections = scanner.scan(text);
+        let redactor = Redactor::new(RedactionStrategy::PartialMasking);
+        let result = redactor.redact(text, &detections);
+        assert_eq!(result, "SSN: ***-**-6789, MRN: ****5678");
+    }
+
+    #[test]
+    fn test_placeholder_substitution() {
+        let text = "SSN: 123-45-6789, MRN: 12345678";
+        let scanner = Scanner::new(PHIPattern::all_patterns(), 0);
+        let detections = scanner.scan(text);
+        let redactor = Redactor::new(RedactionStrategy::PlaceholderSubstitution);
+        let result = redactor.redact(text, &detections);
+        assert_eq!(result, "SSN: [REDACTED-SSN], MRN: [REDACTED-MRN]");
+    }
+
+    #[test]
+    fn test_overlapping_matches() {
+        let text = "NIK: 1234567890123456, BPJS: 1234567890123";
+        let scanner = Scanner::new(PHIPattern::all_patterns(), 0);
+        let detections = scanner.scan(text);
+        let redactor = Redactor::new(RedactionStrategy::FullReplacement);
+        let result = redactor.redact(text, &detections);
+        assert_eq!(result, "NIK: [REDACTED-NIK], BPJS: [REDACTED-BPJS]");
+    }
+}

--- a/phi-detector/src/redactor.rs
+++ b/phi-detector/src/redactor.rs
@@ -30,7 +30,8 @@ impl Redactor {
                 redacted.push_str(&replacement);
                 last = det.end;
             }
-            // If overlaps, skip (already handled by previous match)
+            // Skip if this detection overlaps with an already processed one
+            // (start position is before the end of the last processed detection)
         }
         redacted.push_str(&text[last..]);
         redacted

--- a/tasks/task_001.txt
+++ b/tasks/task_001.txt
@@ -29,13 +29,13 @@ Create a file handling module that can: recursively traverse directories if spec
 ### Details:
 Create a dedicated module for PHI pattern definitions. Implement regex patterns for: SSNs (format: XXX-XX-XXXX), Medical Record Numbers (various formats), ICD-10 codes (letter followed by 2 digits, optional decimal and more digits), and basic date of birth patterns. Use the regex crate with compiled regex patterns for performance. Create a PHIType enum to categorize different types of detected PHI. Implement unit tests for each pattern with both matching and non-matching examples.
 
-## 4. Implement PHI scanning and detection engine [in-progress]
+## 4. Implement PHI scanning and detection engine [done]
 ### Dependencies: 1.2, 1.3
 ### Description: Create the core scanning logic that applies regex patterns to file contents
 ### Details:
 Develop a Scanner struct that takes file content and applies all PHI detection patterns. For each match, record the match text, position, PHI type, and confidence level. Implement context extraction to capture surrounding text for verification. Create a Detection struct to hold match details. Optimize for performance by using appropriate regex options and processing strategies. Add unit and integration tests with sample text containing various PHI patterns.
 
-## 5. Implement redaction functionality [pending]
+## 5. Implement redaction functionality [in-progress]
 ### Dependencies: 1.4
 ### Description: Create a module to redact or mask detected PHI in the original text
 ### Details:

--- a/tasks/tasks.json
+++ b/tasks/tasks.json
@@ -42,7 +42,7 @@
           "id": 4,
           "title": "Implement PHI scanning and detection engine",
           "description": "Create the core scanning logic that applies regex patterns to file contents",
-          "status": "in-progress",
+          "status": "done",
           "dependencies": [
             2,
             3
@@ -53,7 +53,7 @@
           "id": 5,
           "title": "Implement redaction functionality",
           "description": "Create a module to redact or mask detected PHI in the original text",
-          "status": "pending",
+          "status": "in-progress",
           "dependencies": [
             4
           ],


### PR DESCRIPTION
### 1.5. Implement redaction functionality

#### Description: Create a module to redact or mask detected PHI in the original text

#### Details:
Implement a Redactor struct that takes Detection objects and original text to produce redacted output. Create different redaction strategies: full replacement (e.g., 'XXX-XX-XXXX' for SSNs), partial masking (e.g., showing only last 4 digits), and placeholder substitution (e.g., '[REDACTED-SSN]'). Ensure redaction preserves text layout and length where appropriate. Handle overlapping matches correctly. Add configuration options to control redaction behavior. Write tests to verify redaction correctness with various PHI types.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced configurable redaction functionality to obscure detected personal health information (PHI) in text, supporting multiple redaction strategies such as full replacement, partial masking, and placeholder substitution.
- **Documentation**
  - Updated task status to reflect completion of the PHI scanning engine and progress on redaction functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->