### PR TITLE
Task 2.1

### DIFF
--- a/phi-detector/Cargo.lock
+++ b/phi-detector/Cargo.lock
@@ -133,6 +133,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -161,6 +167,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -177,6 +189,16 @@ name = "humantime"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
+
+[[package]]
+name = "indexmap"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
 
 [[package]]
 name = "is-terminal"
@@ -241,6 +263,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "serde_yaml",
  "tempfile",
  "thiserror",
 ]
@@ -350,6 +373,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -413,6 +449,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "utf8parse"

--- a/phi-detector/Cargo.toml
+++ b/phi-detector/Cargo.toml
@@ -15,6 +15,7 @@ tempfile = "3.10"
 regex = "1.10"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+serde_yaml = "0.9"
 log = "0.4"
 env_logger = "0.10"
 thiserror = "1.0"

--- a/phi-detector/README.md
+++ b/phi-detector/README.md
@@ -38,6 +38,55 @@ phi-detector --input data/ --output json --redact -vv
 
 - See `tests/integration_pipeline.rs` for end-to-end pipeline tests
 
+## YAML Configuration (Custom PHI Patterns)
+
+PHI patterns can be defined and extended using a YAML configuration file. This enables you to add, remove, or modify detection rules without changing Rust code.
+
+### Example: `config/phi_patterns.yaml`
+
+```yaml
+patterns:
+  - id: "ssn"
+    name: "Social Security Number"
+    regex: "\\b\\d{3}-\\d{2}-\\d{4}\\b"
+    redaction:
+      template: "[REDACTED-SSN]"
+      strategy: "full"
+  - id: "indonesian_nik"
+    name: "Indonesian NIK"
+    regex: "\\b\\d{16}\\b"
+    redaction:
+      template: "[REDACTED-NIK]"
+      strategy: "full"
+# ... see full schema in config/phi_patterns.yaml
+```
+
+### Loading Patterns from YAML
+
+You can load PHI patterns from a YAML file at runtime:
+
+```rust
+use phi_detector::phi_patterns::PHIPatternConfig;
+
+let patterns_file = PHIPatternConfig::from_yaml_file("config/phi_patterns.yaml")?;
+for pat in patterns_file.patterns {
+    println!("Loaded pattern: {} - {}", pat.id, pat.name);
+}
+```
+
+- The loader validates the YAML structure and returns an error for invalid files.
+- See tests in `src/phi_patterns.rs` for usage examples.
+
+### Testing Configuration Loading
+
+Run the Rust tests to validate YAML loading and error handling:
+
+```sh
+cargo test --lib -- phi_patterns::config_tests
+```
+
+- Tests cover loading valid YAML, handling invalid YAML, and basic pattern field checks.
+
 ---
 
 For more details on usage, options, and contributing, see CLI help (`phi-detector --help`) or open an issue.

--- a/phi-detector/config/phi_patterns.schema.json
+++ b/phi-detector/config/phi_patterns.schema.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "PHI Patterns Configuration",
+  "type": "object",
+  "properties": {
+    "patterns": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "name", "regex", "redaction"],
+        "properties": {
+          "id": { "type": "string" },
+          "name": { "type": "string" },
+          "description": { "type": "string" },
+          "regex": { "type": "string" },
+          "context": {
+            "type": "object",
+            "properties": {
+              "before": { "type": "array", "items": { "type": "string" } },
+              "after": { "type": "array", "items": { "type": "string" } },
+              "window": { "type": "integer", "minimum": 0 }
+            },
+            "additionalProperties": false
+          },
+          "confidence": { "type": "number", "minimum": 0, "maximum": 1 },
+          "redaction": {
+            "type": "object",
+            "required": ["template", "strategy"],
+            "properties": {
+              "template": { "type": "string" },
+              "strategy": { "type": "string", "enum": ["full", "partial", "custom"] }
+            },
+            "additionalProperties": false
+          },
+          "metadata": {
+            "type": "object",
+            "properties": {
+              "category": { "type": "string" },
+              "severity": { "type": "string", "enum": ["low", "medium", "high"] },
+              "examples": { "type": "array", "items": { "type": "string" } }
+            },
+            "additionalProperties": true
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "defaults": {
+      "type": "object",
+      "properties": {
+        "confidence": { "type": "number", "minimum": 0, "maximum": 1 },
+        "redaction": {
+          "type": "object",
+          "properties": {
+            "template": { "type": "string" },
+            "strategy": { "type": "string" }
+          },
+          "additionalProperties": false
+        },
+        "context": {
+          "type": "object",
+          "properties": {
+            "window": { "type": "integer", "minimum": 0 }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "overrides": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  },
+  "required": ["patterns"],
+  "additionalProperties": false
+}

--- a/phi-detector/config/phi_patterns.yaml
+++ b/phi-detector/config/phi_patterns.yaml
@@ -1,0 +1,118 @@
+# Example PHI patterns YAML configuration for healthwand phi-detector
+patterns:
+  - id: "ssn"
+    name: "Social Security Number"
+    description: "Detects US Social Security Numbers"
+    regex: "\\b\\d{3}-\\d{2}-\\d{4}\\b"
+    context:
+      before: ["ssn", "social security"]
+      after: []
+      window: 10
+    confidence: 0.95
+    redaction:
+      template: "[REDACTED-SSN]"
+      strategy: "full"
+    metadata:
+      category: "identifier"
+      severity: "high"
+      examples:
+        - "123-45-6789"
+        - "987-65-4321"
+  - id: "mrn"
+    name: "Medical Record Number"
+    description: "Detects generic MRNs"
+    regex: "\\bMRN[:\\s]*\\d{6,10}\\b"
+    context:
+      before: ["mrn", "medical record number"]
+      after: []
+      window: 8
+    confidence: 0.90
+    redaction:
+      template: "[REDACTED-MRN]"
+      strategy: "partial"
+    metadata:
+      category: "medical"
+      severity: "medium"
+      examples:
+        - "MRN: 123456789"
+        - "Medical record number 987654"
+  - id: "icd10"
+    name: "ICD-10 Code"
+    description: "Detects ICD-10 medical codes"
+    regex: "\\b[A-TV-Z][0-9]{2}(\\.[A-Z0-9]{1,4})?\\b"
+    context:
+      before: ["icd", "icd-10", "diagnosis"]
+      after: []
+      window: 5
+    confidence: 0.85
+    redaction:
+      template: "[REDACTED-ICD10]"
+      strategy: "full"
+    metadata:
+      category: "medical"
+      severity: "medium"
+      examples:
+        - "A12"
+        - "B99.8"
+        - "C01.123"
+  - id: "dob"
+    name: "Date of Birth"
+    description: "Detects dates in common birth date formats"
+    regex: "\\b(\\d{2}/\\d{2}/\\d{4}|\\d{4}-\\d{2}-\\d{2}|\\d{2}/\\d{2}/\\d{4})\\b"
+    context:
+      before: ["dob", "date of birth", "lahir"]
+      after: []
+      window: 5
+    confidence: 0.80
+    redaction:
+      template: "[REDACTED-DOB]"
+      strategy: "full"
+    metadata:
+      category: "personal"
+      severity: "medium"
+      examples:
+        - "12/31/2000"
+        - "2000-12-31"
+        - "31/12/2000"
+  - id: "indonesian_nik"
+    name: "Indonesian NIK"
+    description: "Detects Indonesian National Identity Number (NIK)"
+    regex: "\\b\\d{16}\\b"
+    context:
+      before: ["nik", "nomor induk kependudukan", "ktp"]
+      after: []
+      window: 6
+    confidence: 0.95
+    redaction:
+      template: "[REDACTED-NIK]"
+      strategy: "full"
+    metadata:
+      category: "identifier"
+      severity: "high"
+      examples:
+        - "1234567890123456"
+  - id: "indonesian_bpjs"
+    name: "Indonesian BPJS"
+    description: "Detects Indonesian BPJS Health Insurance Number"
+    regex: "\\b\\d{13}\\b"
+    context:
+      before: ["bpjs", "bpjs kesehatan", "no bpjs"]
+      after: []
+      window: 6
+    confidence: 0.93
+    redaction:
+      template: "[REDACTED-BPJS]"
+      strategy: "full"
+    metadata:
+      category: "insurance"
+      severity: "high"
+      examples:
+        - "1234567890123"
+defaults:
+  confidence: 0.8
+  redaction:
+    template: "[REDACTED]"
+    strategy: "full"
+  context:
+    window: 5
+overrides: {}

--- a/phi-detector/src/file_source.rs
+++ b/phi-detector/src/file_source.rs
@@ -1,5 +1,5 @@
 use std::fs::{self, File};
-use std::io::{self, BufRead, BufReader, Read};
+use std::io::{self, BufReader, Read};
 use std::path::{Path, PathBuf};
 
 #[derive(Debug)]
@@ -45,13 +45,20 @@ impl LocalFileSource {
 
     fn is_text_file(&self, path: &Path) -> bool {
         if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
-            self.allowed_extensions.iter().any(|x| x.eq_ignore_ascii_case(ext))
+            self.allowed_extensions
+                .iter()
+                .any(|x| x.eq_ignore_ascii_case(ext))
         } else {
             false
         }
     }
 
-    fn collect_files_recursive(&self, dir: &Path, files: &mut Vec<PathBuf>, depth: usize) -> Result<(), FileSourceError> {
+    fn collect_files_recursive(
+        &self,
+        dir: &Path,
+        files: &mut Vec<PathBuf>,
+        depth: usize,
+    ) -> Result<(), FileSourceError> {
         const MAX_DEPTH: usize = 100;
         if depth > MAX_DEPTH {
             return Ok(());
@@ -137,7 +144,7 @@ mod tests {
         let result = fs.files();
         assert!(result.is_err());
         match result {
-            Err(FileSourceError::Io(_)) => {},
+            Err(FileSourceError::Io(_)) => {}
             _ => panic!("Expected Io error for nonexistent root"),
         }
     }
@@ -189,7 +196,7 @@ mod tests {
             match result {
                 Err(FileSourceError::Io(e)) => {
                     assert!(e.kind() == std::io::ErrorKind::PermissionDenied);
-                },
+                }
                 _ => panic!("Expected Io error for permission denied"),
             }
             // Restore permissions so tempdir can clean up

--- a/phi-detector/src/lib.rs
+++ b/phi-detector/src/lib.rs
@@ -1,14 +1,14 @@
 // Library root for phi-detector. Move shared code here for integration testing.
 
-pub mod results;
-pub mod phi_patterns;
-pub mod scanner;
-pub mod redactor;
 pub mod file_source;
+pub mod phi_patterns;
+pub mod redactor;
+pub mod results;
+pub mod scanner;
 
-pub use results::{DetectionResult, ResultsSummary, OutputBundle};
 pub use file_source::{FileSource, LocalFileSource};
 pub use redactor::*;
+pub use results::{DetectionResult, OutputBundle, ResultsSummary};
 
 // Re-export main logic if needed (move from main.rs if used by tests)
 // pub use crate::main_logic;

--- a/phi-detector/src/phi_patterns.rs
+++ b/phi-detector/src/phi_patterns.rs
@@ -1,20 +1,76 @@
 use regex::Regex;
-use serde;
+use serde::{Deserialize, Serialize};
+use std::io::BufReader;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum PHIType {
     SSN,
     MedicalRecordNumber,
     ICD10,
     DateOfBirth,
-    IndonesianNIK, // Indonesian National ID Number
-    IndonesianBPJS, // BPJS Health Insurance Number
+    IndonesianNIK,
+    IndonesianBPJS,
+    // Add more as needed
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PatternContext {
+    pub before: Option<Vec<String>>,
+    pub after: Option<Vec<String>>,
+    pub window: Option<u32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Redaction {
+    pub template: String,
+    pub strategy: String, // Could be enum if you want strong typing
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PatternMetadata {
+    pub category: Option<String>,
+    pub severity: Option<String>,
+    pub examples: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PHIPatternConfig {
+    pub id: String,
+    pub name: String,
+    pub description: Option<String>,
+    pub regex: String,
+    pub context: Option<PatternContext>,
+    pub confidence: Option<f32>,
+    pub redaction: Redaction,
+    pub metadata: Option<PatternMetadata>,
+}
+
+impl PHIPatternConfig {
+    pub fn from_yaml_file<P: AsRef<std::path::Path>>(
+        path: P,
+    ) -> Result<PHIPatternsFile, Box<dyn std::error::Error>> {
+        let file = std::fs::File::open(path)?;
+        let reader = BufReader::new(file);
+        let patterns_file: PHIPatternsFile = serde_yaml::from_reader(reader)?;
+        Ok(patterns_file)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PHIPatternsFile {
+    pub patterns: Vec<PHIPatternConfig>,
+    pub defaults: Option<serde_yaml::Value>,
+    pub overrides: Option<serde_yaml::Value>,
 }
 
 #[derive(Debug, Clone)]
 pub struct PHIPattern {
     pub phi_type: PHIType,
     pub regex: Regex,
+    pub context: Option<PatternContext>,
+    pub confidence: Option<f32>,
+    pub redaction: Redaction,
+    pub metadata: Option<PatternMetadata>,
 }
 
 impl PHIPattern {
@@ -23,31 +79,74 @@ impl PHIPattern {
             PHIPattern {
                 phi_type: PHIType::SSN,
                 regex: Regex::new(r"\b\d{3}-\d{2}-\d{4}\b").unwrap(),
+                context: None,
+                confidence: None,
+                redaction: Redaction {
+                    template: "[REDACTED]".to_string(),
+                    strategy: "full".to_string(),
+                },
+                metadata: None,
             },
             PHIPattern {
                 phi_type: PHIType::MedicalRecordNumber,
                 // Example: 8-12 digit numeric, can be adjusted for real-world formats
                 regex: Regex::new(r"\b\d{8,12}\b").unwrap(),
+                context: None,
+                confidence: None,
+                redaction: Redaction {
+                    template: "[REDACTED]".to_string(),
+                    strategy: "full".to_string(),
+                },
+                metadata: None,
             },
             PHIPattern {
                 phi_type: PHIType::ICD10,
                 // ICD-10: Letter, 2 digits, optional "." and 1-4 more alphanums
                 regex: Regex::new(r"\b[A-TV-Z][0-9]{2}(\.[A-Z0-9]{1,4})?\b").unwrap(),
+                context: None,
+                confidence: None,
+                redaction: Redaction {
+                    template: "[REDACTED]".to_string(),
+                    strategy: "full".to_string(),
+                },
+                metadata: None,
             },
             PHIPattern {
                 phi_type: PHIType::DateOfBirth,
                 // MM/DD/YYYY or YYYY-MM-DD or DD/MM/YYYY (basic)
-                regex: Regex::new(r"\b(\d{2}/\d{2}/\d{4}|\d{4}-\d{2}-\d{2}|\d{2}/\d{2}/\d{4})\b").unwrap(),
+                regex: Regex::new(r"\b(\d{2}/\d{2}/\d{4}|\d{4}-\d{2}-\d{2}|\d{2}/\d{2}/\d{4})\b")
+                    .unwrap(),
+                context: None,
+                confidence: None,
+                redaction: Redaction {
+                    template: "[REDACTED]".to_string(),
+                    strategy: "full".to_string(),
+                },
+                metadata: None,
             },
             PHIPattern {
                 phi_type: PHIType::IndonesianNIK,
                 // NIK: 16 digits, usually no separators
                 regex: Regex::new(r"\b\d{16}\b").unwrap(),
+                context: None,
+                confidence: None,
+                redaction: Redaction {
+                    template: "[REDACTED]".to_string(),
+                    strategy: "full".to_string(),
+                },
+                metadata: None,
             },
             PHIPattern {
                 phi_type: PHIType::IndonesianBPJS,
                 // BPJS: 13 digits
                 regex: Regex::new(r"\b\d{13}\b").unwrap(),
+                context: None,
+                confidence: None,
+                redaction: Redaction {
+                    template: "[REDACTED]".to_string(),
+                    strategy: "full".to_string(),
+                },
+                metadata: None,
             },
         ]
     }
@@ -113,5 +212,44 @@ mod tests {
         assert!(!pat.regex.is_match("123456789012"));
         assert!(!pat.regex.is_match("12345678901234"));
         assert!(!pat.regex.is_match("BPJS1234567890"));
+    }
+}
+
+#[cfg(test)]
+mod config_tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn test_load_patterns_from_yaml() {
+        let yaml = r#"
+patterns:
+  - id: 'ssn'
+    name: 'Social Security Number'
+    regex: "\\b\\d{3}-\\d{2}-\\d{4}\\b"
+    redaction:
+      template: '[REDACTED-SSN]'
+      strategy: 'full'
+"#;
+        let mut tmp = NamedTempFile::new().expect("Failed to create temp file");
+        write!(tmp, "{}", yaml).unwrap();
+        let patterns_file =
+            PHIPatternConfig::from_yaml_file(tmp.path()).expect("Failed to load YAML");
+        assert_eq!(patterns_file.patterns.len(), 1);
+        assert_eq!(patterns_file.patterns[0].id, "ssn");
+        assert_eq!(
+            patterns_file.patterns[0].redaction.template,
+            "[REDACTED-SSN]"
+        );
+    }
+
+    #[test]
+    fn test_invalid_yaml() {
+        let yaml = "not: valid: yaml";
+        let mut tmp = NamedTempFile::new().expect("Failed to create temp file");
+        write!(tmp, "{}", yaml).unwrap();
+        let result = PHIPatternConfig::from_yaml_file(tmp.path());
+        assert!(result.is_err());
     }
 }

--- a/phi-detector/src/results.rs
+++ b/phi-detector/src/results.rs
@@ -1,5 +1,5 @@
-use serde::{Serialize, Deserialize};
 use crate::phi_patterns::PHIType;
+use serde::{Deserialize, Serialize};
 
 /// Represents a single PHI detection result, suitable for JSON output.
 ///

--- a/phi-detector/tests/integration_pipeline.rs
+++ b/phi-detector/tests/integration_pipeline.rs
@@ -1,7 +1,7 @@
 use phi_detector::phi_patterns::PHIType;
-use phi_detector::scanner::Scanner;
-use phi_detector::redactor::{Redactor, RedactionStrategy};
+use phi_detector::redactor::{RedactionStrategy, Redactor};
 use phi_detector::results::{DetectionResult, ResultsSummary};
+use phi_detector::scanner::Scanner;
 
 #[test]
 fn test_full_pipeline_json_output() {
@@ -34,7 +34,10 @@ fn test_pipeline_summary() {
     let detections = scanner.scan(text);
     let mut summary = ResultsSummary::default();
     for det in &detections {
-        *summary.detections_by_type.entry(det.phi_type.clone()).or_insert(0) += 1;
+        *summary
+            .detections_by_type
+            .entry(det.phi_type.clone())
+            .or_insert(0) += 1;
     }
     summary.files_processed += 1;
     summary.total_detections += detections.len();

--- a/tasks/task_002.txt
+++ b/tasks/task_002.txt
@@ -1,6 +1,6 @@
 # Task ID: 2
 # Title: Implement YAML configuration system
-# Status: pending
+# Status: in-progress
 # Dependencies: 1
 # Priority: high
 # Description: Create a YAML-based configuration system for defining custom PHI patterns and detection rules
@@ -11,7 +11,7 @@ Design a YAML schema for defining PHI patterns, including regex patterns, contex
 Create test cases with various configuration scenarios. Validate that custom patterns are correctly loaded and applied. Test error handling for malformed configurations.
 
 # Subtasks:
-## 1. Design YAML schema for PHI patterns [pending]
+## 1. Design YAML schema for PHI patterns [done]
 ### Dependencies: None
 ### Description: Create a comprehensive YAML schema that defines the structure for PHI pattern configurations
 ### Details:

--- a/tasks/tasks.json
+++ b/tasks/tasks.json
@@ -76,7 +76,7 @@
       "id": 2,
       "title": "Implement YAML configuration system",
       "description": "Create a YAML-based configuration system for defining custom PHI patterns and detection rules",
-      "status": "pending",
+      "status": "in-progress",
       "dependencies": [
         1
       ],
@@ -88,7 +88,7 @@
           "id": 1,
           "title": "Design YAML schema for PHI patterns",
           "description": "Create a comprehensive YAML schema that defines the structure for PHI pattern configurations",
-          "status": "pending",
+          "status": "done",
           "dependencies": [],
           "details": "Design a schema that includes: (1) Pattern definitions with regex support, (2) Context rules for determining when patterns apply, (3) Confidence scoring mechanisms, (4) Redaction templates and strategies, (5) Metadata fields for pattern documentation. Create JSON Schema validation rules to ensure configuration correctness. Include examples for common PHI types like names, addresses, medical record numbers, etc. The schema should be extensible for future pattern types while maintaining backward compatibility."
         },


### PR DESCRIPTION
## Task 2.1. Design YAML schema for PHI patterns [done]
### Dependencies: None
### Description: Create a comprehensive YAML schema that defines the structure for PHI pattern configurations
### Details:
Design a schema that includes: (1) Pattern definitions with regex support, (2) Context rules for determining when patterns apply, (3) Confidence scoring mechanisms, (4) Redaction templates and strategies, (5) Metadata fields for pattern documentation. Create JSON Schema validation rules to ensure configuration correctness. Include examples for common PHI types like names, addresses, medical record numbers, etc. The schema should be extensible for future pattern types while maintaining backward compatibility.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring PHI detection patterns via an external YAML file, enabling users to define, modify, or extend detection rules without changing source code.
  - Introduced a sample YAML configuration and a JSON schema for validating PHI pattern files.

- **Documentation**
  - Updated the README with instructions and examples for using YAML-based PHI pattern configuration, including details on validation and testing.

- **Style / Refactor**
  - Improved code formatting, import ordering, and readability across multiple files without affecting functionality.

- **Chores**
  - Updated task statuses to reflect progress on YAML configuration system implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->